### PR TITLE
add ace NVGs to BettIR compatibility list

### DIFF
--- a/addons/misc/BettIR_Compat.hpp
+++ b/addons/misc/BettIR_Compat.hpp
@@ -1,0 +1,57 @@
+class BettIR_Config
+{
+    class CompatibleNightvisionGoggles
+    {
+         class ACE_NVG_Gen1
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+         class ACE_NVG_Gen1_Brown
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+         class ACE_NVG_Gen1_Green
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+		 
+         class ACE_NVG_Gen2
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+		 class ACE_NVG_Gen2_Brown
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+		 class ACE_NVG_Gen2_Black
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+		 
+		 class ACE_NVG_Gen4
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+		 class ACE_NVG_Gen4_Black
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+		 class ACE_NVG_Gen4_Green
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+		 
+		 class ACE_NVG_Wide
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+		 class ACE_NVG_Wide_Black
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+		 class ACE_NVG_Wide_Green
+         {
+              offset[] = {0, 0.15,0.1};
+         };
+    };
+};

--- a/addons/misc/config.cpp
+++ b/addons/misc/config.cpp
@@ -12,7 +12,7 @@ class CfgPatches {
             requiredVersion = REQUIRED_VERSION; 
             // Required addons, used for setting load order.
             // When any of the addons is missing, pop-up warning will appear when launching the game.
-            requiredAddons[] = { "ghg_main", "A3_Ui_F", "A3_Missions_F_Oldman", "A3_Ui_F_Orange", "A3_missions_f_aow","A3_missions_f_tacops","missions_f_lxws", "ui_f_vietnam", "ui_f_vietnam_c", "functions_f_vietnam", "rhs_pontoon", "rhs_kraz255" };
+            requiredAddons[] = { "ghg_main", "A3_Ui_F", "A3_Missions_F_Oldman", "A3_Ui_F_Orange", "A3_missions_f_aow","A3_missions_f_tacops","missions_f_lxws", "ui_f_vietnam", "ui_f_vietnam_c", "functions_f_vietnam", "rhs_pontoon", "rhs_kraz255", "BettIR_Core" };
             // List of objects (CfgVehicles classes) contained in the addon. Important also for Zeus content (units and groups) unlocking.
             units[] = {"ghg_spikestrip"};
             // List of weapons (CfgWeapons classes) contained in the addon.
@@ -83,4 +83,5 @@ class CfgCommands {
 #include "CfgVehicles.hpp"
 #include "CfgSounds.hpp"
 #include "CfgWeapons.hpp"
+#include "BettIR_Compat.hpp"
 #include "ui\ui.hpp"


### PR DESCRIPTION
When complete:

Will make ACE altered NVGs compatible with the Goggle IR Illuminator